### PR TITLE
feat: support Github's merge queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Publish it for use with:
   circleci orb publish /tmp/orb.yml affinity/path-filtering@<version tag created below>
 ```
 
-### How to Publish An New Release
+### How to Publish A New Release
 1. Merge pull requests with desired changes to the main branch.
     - For the best experience, squash-and-merge and use [Conventional Commit Messages](https://conventionalcommits.org/).
 2. Find the current version of the orb.

--- a/src/commands/set-parameters.yml
+++ b/src/commands/set-parameters.yml
@@ -28,6 +28,10 @@ parameters:
     description: >
       The location of the config to continue the pipeline with, please note that this parameter
       will be ignored if the user passes the config file per mapping in the mapping parameter
+  enable_merge_queue_support:
+    type: boolean
+    description: "Set to true if you use Github merge queue"
+    default: false
 
 steps:
   - run:
@@ -38,4 +42,5 @@ steps:
         OUTPUT_PATH: << parameters.output-path >>
         CONFIG_PATH: << parameters.config-path >>
         CREATE_PIPELINE_SCRIPT: <<include(scripts/create-parameters.py)>>
+        MERGE_QUEUE_SUPPORT: << parameters.enable_merge_queue_support >>
       command: <<include(scripts/create-parameters.sh)>>

--- a/src/commands/set-parameters.yml
+++ b/src/commands/set-parameters.yml
@@ -30,7 +30,7 @@ parameters:
       will be ignored if the user passes the config file per mapping in the mapping parameter
   enable_merge_queue_support:
     type: boolean
-    description: "Set to true if you use Github merge queue"
+    description: "Set to true if you use Github merge queue. Requires a context with a CIRCLECI_ACCESS_TOKEN set for API access"
     default: false
 
 steps:

--- a/src/examples/path_filtering.yml
+++ b/src/examples/path_filtering.yml
@@ -5,7 +5,7 @@ usage:
   version: 2.1
   setup: true
   orbs:
-    path-filtering: affinity/path-filtering@0.9.1
+    path-filtering: affinity/path-filtering@0.9.2
   workflows:
     generate-config:
       jobs:

--- a/src/examples/path_filtering.yml
+++ b/src/examples/path_filtering.yml
@@ -15,6 +15,9 @@ usage:
             enable_shallow_checkout: true
             checkout_shallow_depth: 200
             checkout_shallow_fetch_depth: 200
+            # This repo uses Github's merge queue; this will enable support for it
+            # to find the proper merge base when multiple commits are merged in one push
+            enable_merge_queue_support: true
             config-path: .circleci/continue_config.yml
             mapping: |
               src/.* build-code true

--- a/src/executors/default.yml
+++ b/src/executors/default.yml
@@ -7,7 +7,7 @@ docker:
 parameters:
   tag:
     type: string
-    default: "3.8"
+    default: "3.12"
     description: >
       Pick a specific cimg/python image variant:
       https://hub.docker.com/r/cimg/python/tags

--- a/src/jobs/filter.yml
+++ b/src/jobs/filter.yml
@@ -55,7 +55,7 @@ parameters:
     default: "small"
   tag:
     type: string
-    default: "3.8"
+    default: "3.12"
     description: >
       Pick a specific cimg/python image variant:
       https://hub.docker.com/r/cimg/python/tags
@@ -75,6 +75,10 @@ parameters:
     type: integer
     description: "shallow checkout fetch depth"
     default: 100
+  enable_merge_queue_support:
+    type: boolean
+    description: "Set to true if you use Github merge queue"
+    default: false
 
 circleci_ip_ranges: << parameters.circleci_ip_ranges >>
 
@@ -103,6 +107,7 @@ steps:
       mapping: << parameters.mapping >>
       output-path: << parameters.output-path >>
       config-path: << parameters.config-path >>
+      enable_merge_queue_support: << parameters.enable_merge_queue_support >>
   - generate-config:
       config-list-path: /tmp/filtered-config-list
       generated-config-path: "/tmp/generated-config.yml"

--- a/src/jobs/filter.yml
+++ b/src/jobs/filter.yml
@@ -77,7 +77,7 @@ parameters:
     default: 100
   enable_merge_queue_support:
     type: boolean
-    description: "Set to true if you use Github merge queue"
+    description: "Set to true if you use Github merge queue. Requires a context with a CIRCLECI_ACCESS_TOKEN set for API access"
     default: false
 
 circleci_ip_ranges: << parameters.circleci_ip_ranges >>

--- a/src/scripts/create-parameters.py
+++ b/src/scripts/create-parameters.py
@@ -2,6 +2,9 @@ import json
 import os
 import re
 import subprocess
+import sys
+import urllib.request
+import urllib.error
 from functools import partial
 
 def checkout(revision):
@@ -16,6 +19,24 @@ def checkout(revision):
     check=True
   )
 
+
+def get_github_org_from_url(git_url):
+  """
+  Extract GitHub organization name from a git URL
+
+  :param git_url: Git URL in the format git@github.com:org/repo.git
+  :return: Organization name
+  """
+  # Check if the URL is in the expected format
+  if git_url.startswith('git@github.com:'):
+    # Split by colon and get the second part
+    parts = git_url.split(':')[1]
+    # Split by slash and get the first part
+    org_name = parts.split('/')[0]
+    return org_name
+
+  return None
+
 def merge_base(base, head):
   return subprocess.run(
     ['git', 'merge-base', base, head],
@@ -23,12 +44,89 @@ def merge_base(base, head):
     capture_output=True
   ).stdout.decode('utf-8').strip()
 
-def parent_commit():
-  return subprocess.run(
-    ['git', 'rev-parse', 'HEAD~1'],
-    check=True,
-    capture_output=True
-  ).stdout.decode('utf-8').strip()
+def extract_vcs_revision(json_data):
+  """
+  Parses JSON data and extracts the 'vcs_revision' from the first element
+  if the data is a list, or directly if it's a dictionary.
+
+  Args:
+      json_data (str): A string containing the JSON response.
+
+  Returns:
+      str: The vcs_revision value, or None if not found or on error.
+  """
+  try:
+    data = json.loads(json_data)
+
+    # Check if the response is a list (like from the CircleCI builds endpoint)
+    if isinstance(data, list):
+      if data:  # Check if the list is not empty
+        first_item = data[0]
+        if isinstance(first_item, dict) and 'vcs_revision' in first_item:
+          return first_item['vcs_revision']
+        else:
+          print("Error: First item in the list is not a dictionary or does not contain 'vcs_revision'.",
+                file=sys.stderr)
+          return None
+      else:
+        print("Error: JSON response is an empty list.", file=sys.stderr)
+        return None
+    # Check if the response is a dictionary itself
+    elif isinstance(data, dict):
+      if 'vcs_revision' in data:
+        return data['vcs_revision']
+      else:
+        print("Error: JSON dictionary does not contain 'vcs_revision'.", file=sys.stderr)
+        return None
+    else:
+      print("Error: Unexpected JSON structure.", file=sys.stderr)
+      return None
+
+  except json.JSONDecodeError as e:
+    print(f"Error decoding JSON: {e}", file=sys.stderr)
+    return None
+  except Exception as e:
+    print(f"An unexpected error occurred: {e}", file=sys.stderr)
+    return None
+
+def parent_commit(merge_queue_support):
+  branch = os.environ.get('CIRCLE_BRANCH')
+  repo_name = os.environ.get('CIRCLE_PROJECT_REPONAME')
+  org_name = get_github_org_from_url(os.environ.get('CIRCLE_REPOSITORY_URL'))
+
+  # If using GitHub's merge queue, several commits can be merged into the main branch
+  # at once, but only one webhook is sent for the entire merge queue. In this case, we need to
+  # use the CircleCI API to get the last commit that was built for the branch to ensure
+  # we are using the correct commit as the base for our diff.
+  if merge_queue_support and (branch == 'master' or branch == 'main'):
+    print(f"Merge Queue support is enabled, using CircleCI API to get the previously built commit on {branch}")
+    # make a request to CircleCI API to get the latest build for the branch, we'll use that as our base
+    url = f'https://circleci.com/api/v1.1/project/github/{org_name}/{repo_name}/tree/{branch}?limit=1'
+
+    req = urllib.request.Request(
+      url,
+      headers={'Accept': 'application/json', 'Circle-Token': os.environ.get('CIRCLECI_ACCESS_TOKEN')}
+    )
+
+    try:
+      # Make the request and get the response
+      with urllib.request.urlopen(req) as response:
+        data = response.read().decode(response.headers.get_content_charset("utf-8"))
+    except urllib.error.HTTPError as e:
+      raise Exception(f"HTTP Error: {e.code} - {e.reason}")
+    except urllib.error.URLError as e:
+      raise Exception(f"URL Error: {e.reason}")
+
+    previous_sha = extract_vcs_revision(data)
+    print (f"Previous SHA: {previous_sha}")
+    return previous_sha
+
+  else:
+    return subprocess.run(
+      ['git', 'rev-parse', 'HEAD~1'],
+      check=True,
+      capture_output=True
+    ).stdout.decode('utf-8').strip()
 
 def changed_files(base, head):
   return subprocess.run(
@@ -111,10 +209,12 @@ def is_mapping_line(line: str) -> bool:
   is_comment_line = (line.strip().startswith("#"))
   return not (is_comment_line or is_empty_line)
 
-def create_parameters(output_path, config_path, head, base, mapping):
+def create_parameters(output_path, config_path, head, base, mapping, merge_queue_support):
   checkout(base)  # Checkout base revision to make sure it is available for comparison
   checkout(head)  # return to head commit
   base = merge_base(base, head)
+
+  print(f"Merge Queue support: {merge_queue_support}")
 
   if head == base:
     try:
@@ -122,7 +222,7 @@ def create_parameters(output_path, config_path, head, base, mapping):
       # current commit as merge base. In that case try to go back to the
       # first parent, i.e. the last state of this branch before the
       # merge, and use that as the base.
-      base = parent_commit()
+      base = parent_commit(merge_queue_support)
     except:
       # This can fail if this is the first commit of the repo, so that
       # HEAD~1 actually doesn't resolve. In this case we can compare
@@ -153,5 +253,6 @@ if __name__ == "__main__":
     os.environ.get('CONFIG_PATH'),
     os.environ.get('CIRCLE_SHA1'),
     os.environ.get('BASE_REVISION'),
-    os.environ.get('MAPPING')
+    os.environ.get('MAPPING'),
+    os.environ.get('MERGE_QUEUE_SUPPORT', 'False').lower() in ('true', '1', 't')
   )

--- a/src/scripts/create-parameters.py
+++ b/src/scripts/create-parameters.py
@@ -109,7 +109,6 @@ def parent_commit(merge_queue_support):
     )
 
     try:
-      # Make the request and get the response
       with urllib.request.urlopen(req) as response:
         data = response.read().decode(response.headers.get_content_charset("utf-8"))
     except urllib.error.HTTPError as e:
@@ -118,7 +117,9 @@ def parent_commit(merge_queue_support):
       raise Exception(f"URL Error: {e.reason}")
 
     previous_sha = extract_vcs_revision(data)
-    print (f"Previous SHA: {previous_sha}")
+    if previous_sha is None:
+      raise Exception("Could not find a previous build to use as base.")
+
     return previous_sha
 
   else:


### PR DESCRIPTION
There is a problem that we encounter using GitHub's merge queue, which is that several commits (ie. the merge group) can be merged in one push to the master/main branch and only one webhook, for the commit at HEAD is sent to CircleCI. That results in some builds not firing because they were in the commits for which no webhook was sent. 

This attempts to resolve that by adding a new param `enable_merge_queue_support`, that when enabled, will use the CircleCI API to find the commit SHA for the previous build on the branch to use as the base-revision.

requires that you have a context with `CIRCLECI_ACCESS_TOKEN` set.

see comments inline for more info.

You can see a test run with this enabled [here](https://app.circleci.com/pipelines/github/affinity/affinity/199378/workflows/5e88eb97-6ad2-45bc-ba72-611b0aa716b9/jobs/2230655). Look at the output in the set-parameters job