### PR TITLE
fix: avoid spurious full-tree rebuilds and unsafe regex anchoring

### DIFF
--- a/src/scripts/create-parameters.py
+++ b/src/scripts/create-parameters.py
@@ -187,7 +187,10 @@ def write_parameters_from_mappings(mappings, changes, output_path, config_path):
         Found {} of type {}
         """.format(decoded_param_value, type(decoded_param_value)))
 
-    regex = re.compile(r'^' + path + r'$')
+    # Wrap in a non-capturing group so user patterns containing top-level
+    # `|` (e.g. `src/.*|docs/.*`) stay anchored. Without the group,
+    # `^src/.*|docs/.*$` is parsed as `^src/.*` OR `docs/.*$`.
+    regex = re.compile(r'^(?:' + path + r')$')
     for change in changes:
       if regex.match(change):
         filtered_mapping.append([param, decoded_param_value])
@@ -224,12 +227,16 @@ def create_parameters(output_path, config_path, head, base, mapping, merge_queue
       # first parent, i.e. the last state of this branch before the
       # merge, and use that as the base.
       base = parent_commit(merge_queue_support)
-    except:
-      # This can fail if this is the first commit of the repo, so that
-      # HEAD~1 actually doesn't resolve. In this case we can compare
-      # against this magic SHA below, which is the empty tree. The diff
-      # to that is just the first commit as patch.
+    except subprocess.CalledProcessError:
+      # `git rev-parse HEAD~1` failed: this is the first commit of the
+      # repo, so HEAD~1 doesn't resolve. Compare against the empty-tree
+      # SHA so the diff is the first commit as a patch.
       base = '4b825dc642cb6eb9a060e54bf8d69288fbee4904'
+    # NOTE: API/network errors from parent_commit() are intentionally NOT
+    # caught here. Falling back to the empty tree on a transient failure
+    # would mark every file as changed and trigger every downstream
+    # workflow. Better to fail the filter job loudly than to silently
+    # rebuild the world.
 
   print('Comparing {}...{}'.format(base, head))
   changes = changed_files(base, head)

--- a/src/scripts/create-parameters.sh
+++ b/src/scripts/create-parameters.sh
@@ -1,35 +1,12 @@
-#!/bin/bash 
+#!/bin/bash
 set -e
 set -o pipefail
 
-if [ -f .python-version ]; then
-    # Create a temp directory
-    circleci_temp_dir="$(mktemp -d)"
-    # Move .python-version out of the directory
-    mv .python-version "$circleci_temp_dir"/.python-version
-fi
-
-curl "https://bootstrap.pypa.io/get-pip.py" -o "circleci_get_pip.py"
-python3 circleci_get_pip.py --user
-
-python3 -m pip install --user virtualenv
-
-echo "Create python virtual environment for path-filtering"
-virtualenv path-filtering-venv -p /usr/bin/python3
-
-echo "Activate python virtual environment"
-# shellcheck source=/dev/null
-. path-filtering-venv/bin/activate
+# create-parameters.py uses only the Python standard library, so no pip /
+# virtualenv bootstrap is required. We just need a python3 on PATH, which
+# the cimg/python executor already provides.
 
 echo "${CREATE_PIPELINE_SCRIPT}" > circleci_create_parameters_script.py
 
 echo "Creating pipeline parameters"
 python3 circleci_create_parameters_script.py
-
-if [ -f "$circleci_temp_dir"/.python-version ]; then
-    # Move .python-version back
-    mv "$circleci_temp_dir"/.python-version .python-version
-fi
-
-echo "Deactivate python virtual environment for path-filtering"
-deactivate


### PR DESCRIPTION
## Summary

Three small fixes that reduce filter-job runs producing more downstream builds than necessary, plus drop a wasteful per-job Python bootstrap.

- **Narrow the `except:` around `parent_commit()`** — when the CircleCI API call (added for merge-queue support) fails for any reason — HTTP error, expired/missing `CIRCLECI_ACCESS_TOKEN`, network blip, parse error — the bare `except:` was silently catching it and setting the diff base to the empty-tree SHA. That marks every file as changed, so every downstream workflow runs. Now we only fall back to the empty-tree SHA on the legitimate "first commit of the repo" case (`git rev-parse HEAD~1` raising `CalledProcessError`); API/network failures propagate and fail the filter job loudly.

- **Wrap user regexes in `(?:...)` before anchoring** — `^foo|bar$` parses as `^foo` OR `bar$`, not `^(foo|bar)$`. A mapping like `src/.*|docs/.*` was therefore matching files anywhere with `docs/` as a suffix, triggering workflows the user didn't ask for. Wrapping in a non-capturing group keeps the anchors honest.

- **Drop pip + virtualenv bootstrap from `create-parameters.sh`** — the embedded Python script uses only stdlib (`json`, `os`, `re`, `subprocess`, `sys`, `urllib`, `functools`). The pre-existing `get-pip.py` curl + `pip install virtualenv` + venv create-and-activate was ~10s of pure overhead on every filter job for no benefit. The `cimg/python` executor already provides `python3` on PATH.

## Why these three first

Out of the broader review I did locally, these are the smallest, lowest-risk, highest-impact changes — they don't change the orb's parameters or interface, they don't touch the merge-queue logic itself, and the second fix is a strict superset of the previous regex behavior (any pattern that worked before still works; some patterns that previously misbehaved now do what users meant).

A few related items were intentionally **left out** of this PR for a follow-up:
- using `merge-base(previous_sha, HEAD)` instead of `previous_sha` directly to avoid overlap with concurrent in-flight merge-queue builds
- making the `'main'/'master'` branch check configurable
- a `previous_sha != CIRCLE_SHA1` sanity check
- reconsidering the shallow-checkout interaction when `previous_sha` is outside the shallow window

## Test plan

- [ ] Filter job still runs and emits `/tmp/pipeline-parameters.json` for a normal feature-branch build (where `head != base` and the API path isn't taken)
- [ ] Filter job still runs on `main` with `enable_merge_queue_support: true` and computes the expected diff
- [ ] Confirm with `enable_merge_queue_support: true` and an intentionally bad `CIRCLECI_ACCESS_TOKEN` that the filter job now **fails** rather than silently triggering every workflow
- [ ] Confirm a mapping pattern with `|` (e.g. `src/.*|docs/.*`) is anchored as the user expects
- [ ] Confirm the simpler `create-parameters.sh` still works on the orb's existing executor (cimg/python)

🤖 Generated with [Claude Code](https://claude.com/claude-code)