### PR TITLE
fix: print actionable error when merge-base cannot be determined

### DIFF
--- a/src/scripts/create-parameters.py
+++ b/src/scripts/create-parameters.py
@@ -38,11 +38,31 @@ def get_github_org_from_url(git_url):
   return None
 
 def merge_base(base, head):
-  return subprocess.run(
+  result = subprocess.run(
     ['git', 'merge-base', base, head],
-    check=True,
     capture_output=True
-  ).stdout.decode('utf-8').strip()
+  )
+  if result.returncode != 0:
+    git_stderr = result.stderr.decode('utf-8').strip()
+    if git_stderr:
+      print(git_stderr, file=sys.stderr)
+    print(f"""
+ERROR: Failed to determine the merge base of '{base}' and '{head}'.
+
+'git merge-base {base} {head}' exited non-zero. This usually means the
+repository was cloned with a shallow checkout and the merge base lies
+outside the fetched history window, i.e. this branch has not merged
+'{base}' recently.
+
+To fix, update your branch and push:
+
+    git fetch origin
+    git merge origin/{base}
+    git push
+
+Then rerun the pipeline.""", file=sys.stderr)
+    sys.exit(1)
+  return result.stdout.decode('utf-8').strip()
 
 def extract_vcs_revision(json_data):
   """

--- a/src/scripts/create-parameters.py
+++ b/src/scripts/create-parameters.py
@@ -43,13 +43,13 @@ def merge_base(base, head):
     capture_output=True
   )
   if result.returncode != 0:
-    git_stderr = result.stderr.decode('utf-8').strip()
+    git_stderr = result.stderr.decode('utf-8', errors='replace').strip()
     if git_stderr:
       print(git_stderr, file=sys.stderr)
     print(f"""
 ERROR: Failed to determine the merge base of '{base}' and '{head}'.
 
-'git merge-base {base} {head}' exited non-zero. This usually means the
+'git merge-base {base} {head}' exited {result.returncode}. This usually means the
 repository was cloned with a shallow checkout and the merge base lies
 outside the fetched history window, i.e. this branch has not merged
 '{base}' recently.
@@ -59,6 +59,8 @@ To fix, update your branch and push:
     git fetch origin
     git merge origin/{base}
     git push
+
+(If your base-revision is not a branch, use 'git merge {base}' instead.)
 
 Then rerun the pipeline.""", file=sys.stderr)
     sys.exit(1)

--- a/src/scripts/create-parameters.py
+++ b/src/scripts/create-parameters.py
@@ -3,6 +3,7 @@ import os
 import re
 import subprocess
 import sys
+import textwrap
 import urllib.request
 import urllib.error
 from functools import partial
@@ -46,23 +47,23 @@ def merge_base(base, head):
     git_stderr = result.stderr.decode('utf-8', errors='replace').strip()
     if git_stderr:
       print(git_stderr, file=sys.stderr)
-    print(f"""
-ERROR: Failed to determine the merge base of '{base}' and '{head}'.
+    print(textwrap.dedent(f"""
+      ERROR: Failed to determine the merge base of '{base}' and '{head}'.
 
-'git merge-base {base} {head}' exited {result.returncode}. This usually means the
-repository was cloned with a shallow checkout and the merge base lies
-outside the fetched history window, i.e. this branch has not merged
-'{base}' recently.
+      'git merge-base {base} {head}' exited {result.returncode}. This usually means the
+      repository was cloned with a shallow checkout and the merge base lies
+      outside the fetched history window, i.e. this branch has not merged
+      '{base}' recently.
 
-To fix, update your branch and push:
+      To fix, update your branch and push:
 
-    git fetch origin
-    git merge origin/{base}
-    git push
+          git fetch origin
+          git merge origin/{base}
+          git push
 
-(If your base-revision is not a branch, use 'git merge {base}' instead.)
+      (If your base-revision is not a branch, use 'git merge {base}' instead.)
 
-Then rerun the pipeline.""", file=sys.stderr)
+      Then rerun the pipeline."""), file=sys.stderr)
     sys.exit(1)
   return result.stdout.decode('utf-8').strip()
 


### PR DESCRIPTION
## Summary
When the checkout is shallow and a branch has not merged the base revision recently, the merge base can lie outside the fetched history window and `git merge-base` exits non-zero. Today that escapes `merge_base()` as a raw `CalledProcessError` traceback in the "Set parameters" step, with no hint of cause or remedy; it hits affinity PRs whenever a branch falls more than 200 commits behind master (the configured shallow depth). The job still fails, but now prints what failed, why, and the remedy (merge the base branch and push, then rerun the pipeline), with the base branch name interpolated so the message is correct for any `base-revision`. Verified locally: the success path returns the merge-base SHA as before; the failure path prints git's own stderr plus the explanation and exits 1.